### PR TITLE
switch to safer bh.hist.values()

### DIFF
--- a/nicks_plot_utils/Hist1D.py
+++ b/nicks_plot_utils/Hist1D.py
@@ -123,7 +123,7 @@ class Hist1D:
             # If filled not defined set it to lines alpha - 0.1
             fill_alpha = fill_alpha if fill_alpha is not None else alpha - 0.1
 
-            ys = self.hist.view()/np.max(self.hist.view()) if density else self.hist.view()
+            ys = self.hist.values()/np.max(self.hist.values()) if density else self.hist.values()
             ys *= factor
             st = ax.fill_between(x, 0, ys,
                                  alpha=fill_alpha,
@@ -202,11 +202,11 @@ class Hist1D:
 
     @property
     def y(self):
-        return self.hist.view()/np.max(self.hist.view())
+        return self.hist.values()/np.max(self.hist.values())
 
     @property
     def y_counts(self):
-        return self.hist.view()
+        return self.hist.values()
 
     def hist_to_xy(self, density: bool = True):
         """Takes a histogram and makes it into a scatter of x,y
@@ -241,9 +241,9 @@ class Hist1D:
 
         x = slic.axes[0].centers
         if density:
-            y = slic.view()/np.max(slic.view())
+            y = slic.values()/np.max(slic.values())
         else:
-            y = slic.view()
+            y = slic.values()
 
         return (x, y)
 


### PR DESCRIPTION
Bit of a niche bug I found when working with weighted histograms.

`hist.view()` can return different variable types when working with a `bh.hist` object that has been initialised with a different type of storage.  E.g. For a hist object using [`bh.storage.Weights()`](https://boost-histogram.readthedocs.io/en/latest/user-guide/storage.html#weight)), `.view()` will return a tuple containing the `values()` and the `variances()` of the histogram.

Changed the use of `.view()` to `.values()` for consistent behavior of plotting methods, which crashed for the above case.