### PR TITLE
'True' normalisation, and some Hist2D colorbar changes

### DIFF
--- a/nicks_plot_utils/Hist1D.py
+++ b/nicks_plot_utils/Hist1D.py
@@ -123,7 +123,7 @@ class Hist1D:
             # If filled not defined set it to lines alpha - 0.1
             fill_alpha = fill_alpha if fill_alpha is not None else alpha - 0.1
 
-            ys = self.hist.view()/np.max(self.hist.view()) if density else self.hist.view()
+            ys = self.hist.values()/np.max(self.hist.values()) if density else self.hist.values()
             ys *= factor
             st = ax.fill_between(x, 0, ys,
                                  alpha=fill_alpha,
@@ -202,11 +202,11 @@ class Hist1D:
 
     @property
     def y(self):
-        return self.hist.view()/np.max(self.hist.view())
+        return self.hist.values()/np.max(self.hist.values())
 
     @property
     def y_counts(self):
-        return self.hist.view()
+        return self.hist.values()
 
     def hist_to_xy(self, density: bool = True):
         """Takes a histogram and makes it into a scatter of x,y
@@ -241,9 +241,9 @@ class Hist1D:
 
         x = slic.axes[0].centers
         if density:
-            y = slic.view()/np.max(slic.view())
+            y = slic.values()/np.max(slic.values())
         else:
-            y = slic.view()
+            y = slic.values()
 
         return (x, y)
 

--- a/nicks_plot_utils/Hist2D.py
+++ b/nicks_plot_utils/Hist2D.py
@@ -40,6 +40,7 @@ class Hist2D:
                  yrange: List = None,
                  yname: str = None,
                  boost_hist=None,
+                 colorbar = None,
                  *args, **kwargs) -> None:
 
         self.xname = xname
@@ -107,7 +108,8 @@ class Hist2D:
         return self.hist
 
     def plot(self, ax=None,
-             cmap=None, density: bool = True,  colorbar: bool = True, zeros: bool = True, log_cmap: bool = False):
+             cmap=None, density: bool = True, zeros: bool = True, log_cmap: bool = False, 
+             colorbar: bool = True, colorbar_params: dict = {}):
         if not ax:
             ax = plt.gca()
         if density:
@@ -134,7 +136,7 @@ class Hist2D:
         else:
             norm = None
 
-        pc = ax.pcolormesh(*self.hist.axes.edges.T, zvalues.T, norm=norm,
+        pc = ax.pcolormesh(*self.hist.axes.edges.T, zvalues.T, norm=norm, linewidth=0, rasterized=True,
                            cmap=cmap if cmap else 'viridis')
 
         ax.set_xlabel(self.xname)
@@ -142,12 +144,15 @@ class Hist2D:
         ax.set_xlim([np.min(self.hist.axes[0]), np.max(self.hist.axes[0])])
         ax.set_ylim([np.min(self.hist.axes[1]), np.max(self.hist.axes[1])])
         if colorbar:
-            plt.gcf().colorbar(pc, ax=ax, aspect=30)
+            if not colorbar_params:
+                colorbar_params = {'aspect':30} 
+            self.colorbar = plt.gcf().colorbar(pc, ax=ax, **colorbar_params)
         return pc
 
     def plot3D(self, ax=None,
                filled: bool = False, alpha: float = __ALPHA__,
-               cmap=None, density: bool = True,  colorbar: bool = True, zeros: bool = True):
+               cmap=None, density: bool = True, zeros: bool = True,
+                colorbar: bool = True, colorbar_params: dict = {}):
         fig = plt.gcf()
         ax = plt.axes(projection='3d')
         if not ax:
@@ -171,7 +176,9 @@ class Hist2D:
         ax.set_xlabel(self.xname)
         ax.set_ylabel(self.yname)
         if colorbar:
-            plt.gcf().colorbar(pc, ax=ax, aspect=30)
+            if not colorbar_params:
+                colorbar_params = {'aspect':30} 
+            self.cbar = plt.gcf().colorbar(pc, ax=ax, **colorbar_params)
         return pc
 
     def fill(self, data_x, data_y):


### PR DESCRIPTION
Hi Nick, 

Wanted to pass along a couple of changes I've made.

## Hist1D
I've added the calculation for a 'true' normalization (area under the histogram = 1), mirroring matplotlib's definition of `density`.  So as to not interfere with any legacy code, I have called this `density_norm`.  I have also left `density` as the default, but when `density_norm` is used, it supersedes this default behavior, with a warning message to let the user know that `density` has been disabled.

Further to this, I have included the uncertainty calculations for both `density` and `density_norm`.  If no `errorcalc` is specified, but `density` or `density_norm` are used, the correct error calculation is automatically selected.

## Hist2D
In order to be able to do some 'after the fact' colorbar tweaks the `colorbar` is now an object of the class. e.g, after plotting the Hist2D object:

    my2Dhist.colorbar.ax.tick_params(which='major', width=0.7, length=2)
    
Further to this, to enable more control over the colorbar, I have added a 'kwargs' variable `colorbar_params`.
To preserve your default styling, the colorbar `aspect` is set to 20 when no `colorbar_params` argument is provided.

```
cbar_params={
    'pad':-0.05,
    'aspect':20
}
my2Dhist.plot(ax=ax, colorbar_params=cbar_params)

```